### PR TITLE
Added 'shebang' to the inventory script.

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -380,6 +380,7 @@ Puppet Inventory
 ================
 
 .. code-block:: shell
+    #!/usr/bin/env python
 
     import json
     import subprocess


### PR DESCRIPTION
I ran into a cryptic error while trying to use your inventory script, passing it as -i to ansible/ansible-playbook which was caused by it trying to interpret the file as a hosts list instead of executing it.  I had the same error even if the file was set as executable.  
